### PR TITLE
Update 2015-02-27-002-configuration.md

### DIFF
--- a/_posts/2015-02-27-002-configuration.md
+++ b/_posts/2015-02-27-002-configuration.md
@@ -19,9 +19,9 @@ Simply go [here](http://flow.imgtec.com/developers/develop/embedded/pic32mz-free
 
 ![MPIDE FlowCloud installation](/flow-on-arduino/images/MPIDE-flowcloud-install.png)
 
-<!---
-Next you will need to compile the CyaSSL library, to do this follow the instructions under section 2.6 in the getting started guide [here](http://flow.imgtec.com/developers/develop/embedded/pic32mz-free-rtos/downloads). The library will be located in the harmony directory under `third_party/bin/libcyassl.X.a`, copy this to `hardware\pic32\variants\WiFire_Flow\libcyassl.X.a` under the MPIDE directory.
--->
+
+Next you will need to compile the CyaSSL library, to do this follow the instructions under section 2.6 in the Developer Getting Started Guide [here](http://flow.imgtec.com/developers/develop/embedded/pic32mz-free-rtos/downloads). The library will be located in the harmony directory under `third_party/bin/libcyassl.X.a`, copy this to `hardware\pic32\variants\WiFire_Flow\libcyassl.X.a` under the MPIDE directory.
+
 
 ## Programming the WiFire
 


### PR DESCRIPTION
Uncommented paragraph instructing the user to build and copy across libcyassl.a into the MPIDE installation folder.
